### PR TITLE
Fix token format in api-token.txt file

### DIFF
--- a/validator/api-token.txt
+++ b/validator/api-token.txt
@@ -1,1 +1,1 @@
-Authorization: bearer api-token-0x7fd16fff6453982a5d8bf14617e7823b68cd18ade59985befe64e0a659300e7d
+api-token-0x7fd16fff6453982a5d8bf14617e7823b68cd18ade59985befe64e0a659300e7d


### PR DESCRIPTION
The expected token format is `api-token-<32 byte hex string>`, see [keymanager server](https://github.com/ChainSafe/lodestar/blob/unstable/packages/cli/src/cmds/validator/keymanager/server.ts#L52).

At the moment the authorization header which needs to be sent to the keymanager server would have to look like this

```
Authorization: Bearer Authorization: bearer api-token-0x7fd16fff6453982a5d8bf14617e7823b68cd18ade59985befe64e0a659300e7d
```

but it should be like this

```
Authorization: Bearer api-token-0x7fd16fff6453982a5d8bf14617e7823b68cd18ade59985befe64e0a659300e7d
```