### PR TITLE
Update network name from "prater" to "goerli"

### DIFF
--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -36,7 +36,7 @@ fi
 
 exec node /usr/app/node_modules/.bin/lodestar \
     beacon \
-    --network=prater \
+    --network=goerli \
     --jwt-secret=/jwtsecret \
     --execution.urls=$HTTP_ENGINE \
     --dataDir=/var/lib/data \

--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-NETWORK="prater"
+NETWORK="goerli"
 VALIDATOR_PORT=3500
 
 # MEVBOOST: https://github.com/ChainSafe/lodestar/blob/unstable/docs/usage/mev-integration.md


### PR DESCRIPTION
Lodestar does not support "prater" as network, it needs to be changed to "goerli" to avoid the following error:

```
✖ Invalid values:
  Argument: network, Given: "prater", Choices: "mainnet", "gnosis", "goerli", "ropsten", "sepolia", "dev"
```