### PR TITLE
Fix beacon node and validator Dockerfile

### DIFF
--- a/beacon-chain/Dockerfile
+++ b/beacon-chain/Dockerfile
@@ -3,13 +3,13 @@ FROM chainsafe/lodestar:${UPSTREAM_VERSION}
 
 USER root
 RUN apk update && apk add curl
-COPY entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY jwtsecret.hex /jwtsecret
 
-RUN chmod +x /entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
 EXPOSE $BEACON_API_PORT
 
 EXPOSE 9000
 
-ENTRYPOINT ["./entrypoint.sh"]
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -7,4 +7,6 @@ RUN apk update && apk add curl jq
 COPY api-token.txt /var/lib/data/validator-db/api-token.txt
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
 ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -7,4 +7,4 @@ RUN apk update && apk add curl jq
 COPY api-token.txt /var/lib/data/validator-db/api-token.txt
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
-ENTRYPOINT [ "entrypoint.sh" ]
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]


### PR DESCRIPTION
- Fix path to entrypoint scripts
- Make validator entrypoint script executable
- streamlined where the entrypoint scripts are copied to, `/usr/local/bin/` should be the proper place, also aligns better with other packages