### PR TITLE
Update validator beacon node address cli arg

### DIFF
--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -26,7 +26,7 @@ exec node /usr/app/node_modules/.bin/lodestar \
     --keymanager.port 3500 \
     --keymanager.address 0.0.0.0 \
     --externalSigner.url=${HTTP_WEB3SIGNER} \
-    --server=${BEACON_NODE_ADDR} \
+    --beaconNodes=${BEACON_NODE_ADDR} \
     --logLevel=${DEBUG_LEVEL} \
     --logFileLevel=debug \
     --logFileDailyRotate 5 \


### PR DESCRIPTION
Updates `--server` to `--beaconNodes` which is the CLI option where `BEACON_NODE_ADDR` needs to be supplied to

`--server` still works but is just an alias and might be removed in the future