### PR TITLE
Fix beacon-chain entrypoint script interpreter

### DIFF
--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Concatenate EXTRA_OPTS string
 [[ -n "$CHECKPOINT_SYNC_URL" ]] && EXTRA_OPTS="${EXTRA_OPTS} --checkpointSyncUrl=${CHECKPOINT_SYNC_URL}"


### PR DESCRIPTION
Lodestar uses `sh` as default shell, interpreter of entrypoint script needs to be updated to `/bin/sh` else the script will not be found and startup fails.