### PR TITLE
Add suggested fee recipient to beacon node

### DIFF
--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -37,6 +37,7 @@ fi
 exec node /usr/app/node_modules/.bin/lodestar \
     beacon \
     --network=goerli \
+    --suggestedFeeRecipient=${FEE_RECIPIENT_ADDRESS} \
     --jwt-secret=/jwtsecret \
     --execution.urls=$HTTP_ENGINE \
     --dataDir=/var/lib/data \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       CHECKPOINT_SYNC_URL: ""
       P2P_PORT: 9512
       EXTRA_OPTS: ""
+      FEE_RECIPIENT_ADDRESS: ""
   validator:
     image: "validator.lodestar-prater.dnp.dappnode.eth:0.1.0"
     build:

--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -24,7 +24,7 @@ fields:
     target:
       type: environment
       name: FEE_RECIPIENT_ADDRESS
-      service: validator
+      service: [validator, beacon-chain]
     title: Fee Recipient Address
     description: >-
       Fee Recipient is a feature that lets you specify a priority fee recipient address on your validator client instance and beacon node. Make sure this is an address you control. After The Merge, Execution Clients will begin depositing priority fees into this address whenever your validator proposes a new block.


### PR DESCRIPTION
Specify fee recipient default for collecting the EL block fees and rewards in case validator fails to update for a validator index before calling produceBlock.