### PR TITLE
Add option to configure doppelganger protection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       GRAFFITI: validating_from_DAppNode
       EXTRA_OPTS: ""
       FEE_RECIPIENT_ADDRESS: ""
+      DOPPELGANGER_PROTECTION: "true"
 volumes:
   beacon-data: {}
   validator-data: {}

--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -31,3 +31,19 @@ fields:
     required: true
     pattern: "^0x[a-fA-F0-9]{40}$"
     patternErrorMessage: Must be a valid address (0x1fd16a...)
+  - id: doppelgangerProtection
+    target:
+      type: environment
+      name: DOPPELGANGER_PROTECTION
+      service: validator
+    title: Enable Doppelganger Protection
+    description: >-
+      Doppelganger protection attempts to detect other instances of a validator operating on the network before any slashable offenses can be committed.
+      This is achieved by staying silent for 2-3 epochs after a validator is started, so it can listen for other instances of that validator before starting to sign potentially slashable messages.
+
+
+      **Note:** Running the same validator twice will inevitably result in slashing. Doppelganger protection should be considered as a last line of defense that might save a validator from being slashed due to operator error, but there is no guarantee it will detect a duplicate validator before slashing conditions arise.
+    enum:
+      - "true"
+      - "false"
+    required: true

--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -26,7 +26,7 @@ exec node /usr/app/node_modules/.bin/lodestar \
     --metrics.port 5064 \
     --metrics.address 0.0.0.0 \
     --externalSigner.url=${HTTP_WEB3SIGNER} \
-    --doppelgangerProtection \
+    --doppelgangerProtection=${DOPPELGANGER_PROTECTION} \
     --beaconNodes=${BEACON_NODE_ADDR} \
     --logLevel=${DEBUG_LEVEL} \
     --logFileLevel=debug \


### PR DESCRIPTION
**Motivation**

Doppelganger protection is enabled by default on all CL packages. This causes 2-3 missed attestations (or even missed proposals) after every restart such as when upgrading Lodestar to a newer version but DP does not provide any protection in this case.

This is not the best user experience in case a user just wants to update their package (or auto-update) which is the case most of the time.

**Description**

Adds option to setup wizard to configure / disable doppelganger protection. This has been requested / asked by multiple users already.

![image](https://github.com/dappnode/DAppNodePackage-Lodestar-Prater/assets/38436224/39666344-6577-4763-8f12-4ea8efa46f45)


This is already possible right now but is error prone and not obvious by doing the following:

**Config** --> **Show Advanced Editor** --> Add  `--doppelgangerProtection false` to validator `EXTRA_OPTS`

**Additional context**

We can also do better on the implementation side here, I opened an issue on Lodestar for this
- https://github.com/ChainSafe/lodestar/issues/5856
