### PR TITLE
Add env to configure doppelganger protection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       GRAFFITI: validating_from_DAppNode
       EXTRA_OPTS: ""
       FEE_RECIPIENT_ADDRESS: ""
+      DOPPELGANGER_PROTECTION: "true"
 volumes:
   beacon-data: {}
   validator-data: {}

--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -26,7 +26,7 @@ exec node /usr/app/node_modules/.bin/lodestar \
     --metrics.port 5064 \
     --metrics.address 0.0.0.0 \
     --externalSigner.url=${HTTP_WEB3SIGNER} \
-    --doppelgangerProtection \
+    --doppelgangerProtection=${DOPPELGANGER_PROTECTION} \
     --beaconNodes=${BEACON_NODE_ADDR} \
     --logLevel=${DEBUG_LEVEL} \
     --logFileLevel=debug \


### PR DESCRIPTION
Adds environment variable to make it simpler and less error prone to configure / disable doppelganger protection.

This is a simplified version of https://github.com/dappnode/DAppNodePackage-Lodestar-Prater/pull/89 which also added this to setup wizard but it might be better to keep it in advanced settings only to not deviate the Lodestar package too much from other CL packages.

This setting will mostly become irrelevant once Lodestar implements https://github.com/ChainSafe/lodestar/issues/5856.